### PR TITLE
Point to correct repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "author": "Dieter Luypaert <dieterluypaert@gmail.com>",
   "license": "MIT",
-  "repository": "git@github.com:Moeriki/node-millis.git",
+  "repository": "git@github.com:Moeriki/node-mappr.git",
   "main": "index.js",
   "scripts": {
     "lint": "eslint *.js lib/ test/",


### PR DESCRIPTION
Noticed the NPM page points to a different package's repository. Also, not stalking I swear.